### PR TITLE
xen: add constraint 'type id = string' to match unix

### DIFF
--- a/xen/console.mli
+++ b/xen/console.mli
@@ -17,3 +17,4 @@
 (** Text console input/output operations. *)
 include V1.CONSOLE
   with type 'a io = 'a Lwt.t
+  and type id = string


### PR DESCRIPTION
Signed-off-by: David Scott dave.scott@eu.citrix.com
