### PR TITLE
xen: Console.connect will now block waiting for console hotplug

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+trunk (unreleased)
+* [xen]: for secondary consoles, Console.connect blocks in a watch waiting for
+  a hotplug. This allows stand-alone console servers time to connect (such as
+  xentropyd)
 2.0.0 (31-10-2014)
 * enable travis (for both xen and unix cases)
 * fix dependencies: drop mirage-{xen,unix}; keep dependencies on implementation


### PR DESCRIPTION
It's convenient to block in a Xenstore watch rather than immediately
fail because this allows stand-alone console backends to be used,
such as xentropyd.

An application can still choose to die if it doesn't have immediate
access to a console, or die after a timeout, or sit and wait.

Signed-off-by: David Scott dave.scott@citrix.com
