### PR TITLE
require mirage-types.runtime for M_util

### DIFF
--- a/pkg/META.unix
+++ b/pkg/META.unix
@@ -1,6 +1,6 @@
 description = "Console implementation for Unix"
 version = "%%VERSION_NUM%%"
-requires = "lwt mirage-types.lwt result cstruct.lwt"
+requires = "lwt mirage-types.lwt result cstruct.lwt mirage-types.runtime"
 archive(byte) = "mirage-console-unix.cma"
 archive(native) = "mirage-console-unix.cmxa"
 plugin(byte) = "mirage-console-unix.cma"

--- a/pkg/META.xen
+++ b/pkg/META.xen
@@ -1,7 +1,7 @@
 description = "Console implementation for Xen"
 version = "%%VERSION_NUM%%"
 requires =
-"lwt mirage-types mirage-xen io-page xen-gnt xen-evtchn mirage-console-xen-proto"
+"lwt mirage-types mirage-xen io-page xen-gnt xen-evtchn mirage-console-xen-proto mirage-types.runtime"
 archive(byte)   = "mirage-console-xen.cma"
 archive(native) = "mirage-console-xen.cmxa"
 plugin(byte)    = "mirage-console-xen.cma"

--- a/xen/console_xen.ml
+++ b/xen/console_xen.ml
@@ -31,7 +31,8 @@ type 'a io = 'a Lwt.t
 
 (* NEEDED until we change FLOW *)
 let error_message (`Invalid_console msg) =
-  Printf.sprintf "Invalid console '%s'" msg
+  M_util.pp_console_error Format.str_formatter e ;
+  Format.flush_str_formatter ()
 
 let h = Eventchn.init ()
 


### PR DESCRIPTION
I just broke this in #47, sorry.. shouldn't matter for unikernels since there mirage-types.runtime is automatically injected.