### PR TITLE
console_unix and console_xen should be a FLOW with result errors

### DIFF
--- a/_tags
+++ b/_tags
@@ -5,13 +5,13 @@ true: warn_error(+1..49), warn(A-4-41-44)
 
 <unix>: include
 
-<unix/*>: package(mirage-types.lwt lwt result cstruct mirage-runtime)
-<lib_test/*>: package(mirage-types lwt cstruct.lwt cstruct mirage-runtime)
+<unix/*>: package(mirage-types.lwt lwt result cstruct)
+<lib_test/*>: package(mirage-types lwt cstruct.lwt cstruct)
 
 ## Xen
 
 <xen/*>: \
-  package(lwt mirage-runtime mirage-types.lwt mirage-xen xen-gnt xen-evtchn), \
+  package(lwt mirage-types.lwt mirage-xen xen-gnt xen-evtchn), \
   package(mirage-console-xen-proto io-page)
 
 <xen/proto/*>: package(xenstore result rresult)
@@ -25,4 +25,4 @@ true: warn_error(+1..49), warn(A-4-41-44)
   package(xen-evtchn.unix.activations cmdliner xenstore xenstore_transport), \
   package(result cstruct.lwt rresult shared-memory-ring.console xen-gnt), \
   package(xenstore_transport.lwt xen-gnt.unix mirage-console-xen-backend), \
-  package(mirage-runtime mirage-console-unix)
+  package(mirage-console-unix)

--- a/mirage-console-unix.opam
+++ b/mirage-console-unix.opam
@@ -18,5 +18,4 @@ depends: [
   "cstruct"
   "mirage-types-lwt" {>= "3.0.0"}
   "mirage-unix" {>="1.1.0"}
-  "mirage-runtime"
 ]

--- a/mirage-console-xen-cli.opam
+++ b/mirage-console-xen-cli.opam
@@ -18,7 +18,6 @@ depends: [
   "io-page"
   "mirage-types" {> "1.1.0"}
   "mirage-types-lwt" {>= "2.9.0"}
-  "mirage-runtime"
   "cmdliner"
   "mirage-unix" {>="1.1.0"}
   "xenstore_transport" "xenctrl" "xen-gnt"

--- a/mirage-console-xen.opam
+++ b/mirage-console-xen.opam
@@ -16,6 +16,5 @@ depends: [
   "topkg"      {build & >= "0.7.3"}
   "mirage-console-xen-proto"
   "mirage-types-lwt"
-  "mirage-runtime"
   "xen-evtchn" "xen-gnt" "mirage-xen"
 ]

--- a/pkg/META.unix
+++ b/pkg/META.unix
@@ -1,6 +1,6 @@
 description = "Console implementation for Unix"
 version = "%%VERSION_NUM%%"
-requires = "lwt mirage-runtime result cstruct.lwt"
+requires = "lwt result cstruct.lwt"
 archive(byte) = "mirage-console-unix.cma"
 archive(native) = "mirage-console-unix.cmxa"
 plugin(byte) = "mirage-console-unix.cma"

--- a/pkg/META.xen
+++ b/pkg/META.xen
@@ -1,7 +1,7 @@
 description = "Console implementation for Xen"
 version = "%%VERSION_NUM%%"
 requires =
-"lwt mirage-xen io-page xen-gnt xen-evtchn mirage-console-xen-proto mirage-runtime"
+"lwt mirage-xen io-page xen-gnt xen-evtchn mirage-console-xen-proto"
 archive(byte)   = "mirage-console-xen.cma"
 archive(native) = "mirage-console-xen.cmxa"
 plugin(byte)    = "mirage-console-xen.cma"


### PR DESCRIPTION
xen-backend needs flow changes too.

This PR causes mirage-console to build with proposed upstream Mirage 3 API changes. See mirage/mirage#690 for details on the upstream changes to the API.