### PR TITLE
consistently constraint opam files to ocaml >= 4.03.0

### DIFF
--- a/mirage-console-lwt.opam
+++ b/mirage-console-lwt.opam
@@ -20,3 +20,4 @@ depends: [
   "cstruct" {>= "1.9.0"}
   "cstruct-lwt"
 ]
+available: [ocaml-version >= "4.03.0"]

--- a/mirage-console-xen-backend.opam
+++ b/mirage-console-xen-backend.opam
@@ -14,10 +14,10 @@ build: [
 ]
 
 depends: [
-  "ocamlfind" {build}
   "jbuilder"  {build & >="1.0+beta9"}
   "mirage-console-lwt" {>= "2.2.0"}
   "mirage-console-xen-proto"
   "lwt"
   "xenstore" "xen-evtchn" "xen-gnt" "shared-memory-ring-lwt"
 ]
+available: [ocaml-version >= "4.03.0"]

--- a/mirage-console-xen-cli.opam
+++ b/mirage-console-xen-cli.opam
@@ -14,7 +14,6 @@ build: [
 ]
 
 depends: [
-  "ocamlfind" {build}
   "jbuilder"  {build & >="1.0+beta9"}
   "mirage-console" {>= "2.2.0"}
   "mirage-console-lwt" {>= "2.2.0"}

--- a/mirage-console-xen-proto.opam
+++ b/mirage-console-xen-proto.opam
@@ -14,9 +14,9 @@ build: [
 ]
 
 depends: [
-  "ocamlfind" {build}
   "jbuilder"  {build & >="1.0+beta9"}
   "mirage-console-lwt" {>= "2.2.0"}
   "rresult"
   "xenstore"
 ]
+available: [ocaml-version >= "4.03.0"]

--- a/mirage-console-xen.opam
+++ b/mirage-console-xen.opam
@@ -14,7 +14,6 @@ build: [
 ]
 
 depends: [
-  "ocamlfind" {build}
   "jbuilder"  {build & >="1.0+beta9"}
   "mirage-console-lwt" {>= "2.2.0"}
   "mirage-console-xen-proto"

--- a/mirage-console.opam
+++ b/mirage-console.opam
@@ -18,3 +18,4 @@ depends: [
   "mirage-device" {>= "1.0.0"}
   "mirage-flow" {>= "1.2.0"}
 ]
+available: [ocaml-version >= "4.03.0"]


### PR DESCRIPTION
there are several failures on 4.02.3 on use of Result