### PR TITLE
xen: depend on io-page-xen where necessary

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+v2.3.4 2017-06-17
+-----------------
+
+* Depend on OCaml >= 4.03.0 and above
+* Add dependency on io-page-xen
+
 v2.3.3 2017-06-15
 -----------------
 

--- a/mirage-console-xen-backend.opam
+++ b/mirage-console-xen-backend.opam
@@ -18,6 +18,7 @@ depends: [
   "mirage-console-lwt" {>= "2.2.0"}
   "mirage-console-xen-proto"
   "lwt"
+  "io-page-xen" {>= "2.0.0"}
   "xenstore" "xen-evtchn" "xen-gnt" "shared-memory-ring-lwt"
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/mirage-console-xen.opam
+++ b/mirage-console-xen.opam
@@ -19,6 +19,7 @@ depends: [
   "mirage-console-xen-proto"
   "xen-evtchn"
   "xen-gnt"
+  "io-page-xen"
   "mirage-xen"
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/xen/backend/jbuild
+++ b/xen/backend/jbuild
@@ -2,6 +2,6 @@
  ((name mirage_console_xen_backend)
   (public_name mirage-console-xen-backend)
   (libraries (lwt xenstore xenstore.client xen-gnt xen-evtchn shared-memory-ring
-    mirage-console-lwt mirage-console-xen-proto
+    mirage-console-lwt mirage-console-xen-proto io-page-xen
   ))
 ))

--- a/xen/console_xen.ml
+++ b/xen/console_xen.ml
@@ -136,7 +136,7 @@ let get_initial_console () =
   let backend_id = 0 in (* unused *)
   let gnt = Gnt.console in (* unused *)
   let page = Start_info.console_start_page () in
-  let ring = Io_page.to_cstruct page in
+  let ring = page in
   (* We don't need to zero the initial console ring, and doing so may lose boot
    * messages from Mini-OS. *)
 

--- a/xen/jbuild
+++ b/xen/jbuild
@@ -2,6 +2,7 @@
  ((name mirage_console_xen)
   (public_name mirage-console-xen)
   (libraries (lwt xenstore xen-gnt xen-evtchn shared-memory-ring
-    mirage-console-xen-proto mirage-console-lwt mirage-flow mirage-xen))
+    mirage-console-xen-proto mirage-console-lwt mirage-flow mirage-xen
+    io-page-xen))
   (wrapped false)
 ))


### PR DESCRIPTION
- update to the new `mirage-xen` `Cstruct.t` API for the console ring
- explicitly depend on `io-page-xen` where it is needed, rather than rely on linkage via `mirage-xen`

Related to Related to mirage/mirage#836