### PR TITLE
mirage-console-unix: no need for mirage-unix

### DIFF
--- a/mirage-console-unix.opam
+++ b/mirage-console-unix.opam
@@ -19,6 +19,5 @@ depends: [
   "cstruct" {>="3.0.0"}
   "cstruct-lwt"
   "mirage-console-lwt" {>= "2.2.0"}
-  "mirage-unix" {>="1.1.0"}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/mirage-console-xen-cli.opam
+++ b/mirage-console-xen-cli.opam
@@ -23,7 +23,6 @@ depends: [
   "ipaddr"
   "io-page"
   "cmdliner"
-  "mirage-unix" {>="1.1.0"}
   "xenstore_transport" "xenctrl" "xen-gnt"
   "mirage-console-xen-backend" "mirage-console-unix"
 ]


### PR DESCRIPTION
there is a suspicion that mirage-unix is not needed any more...