### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-console-lwt.opam
+++ b/mirage-console-lwt.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-console/"
 bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-console" {=version}
   "lwt"
   "cstruct" {>= "1.9.0"}

--- a/mirage-console-unix.opam
+++ b/mirage-console-unix.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-console/"
 bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "lwt"
   "cstruct" {>= "3.0.0"}
   "cstruct-lwt"

--- a/mirage-console-xen-backend.opam
+++ b/mirage-console-xen-backend.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-console/"
 bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-console-lwt" {=version}
   "mirage-console-xen-proto" {=version}
   "mirage-xen" {>= "4.0.0"}

--- a/mirage-console-xen-proto.opam
+++ b/mirage-console-xen-proto.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-console/"
 bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-console-lwt" {>= "2.2.0"}
   "rresult"
   "xenstore"

--- a/mirage-console-xen.opam
+++ b/mirage-console-xen.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-console/"
 bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-console-lwt" {=version}
   "mirage-console-xen-proto" {=version}
   "xen-evtchn"

--- a/mirage-console.opam
+++ b/mirage-console.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-console/"
 bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-device" {>= "1.0.0"}
   "mirage-flow" {>= "1.2.0"}
 ]


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.