### PR TITLE
compatibility with older mirage

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,5 @@
 (library
  (name mirage_console)
  (public_name mirage-console)
- (libraries mirage-flow mirage-device lwt))
+ (libraries mirage-flow mirage-device lwt)
+ (wrapped false))

--- a/src/mirage_console_lwt.ml
+++ b/src/mirage_console_lwt.ml
@@ -1,0 +1,3 @@
+[@@@ocaml.deprecated "This module will be removed from MirageOS 4.0. Please use Mirage_console instead."]
+
+include Mirage_console


### PR DESCRIPTION
this allows a smooth transition path (mirage 3.6.0 --> 3.7.0) with some deprecations.