### PR TITLE
Update to new Xen core platform stack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ env:
   - PINS="mirage-console:. mirage-console-xen:. mirage-console-unix:. mirage-console-xen-proto:. mirage-console-xen-backend:."
   - DISTRO=alpine
   matrix:
-  - OCAML_VERSION=4.06 PACKAGE="mirage-console"
-  - OCAML_VERSION=4.07 PACKAGE="mirage-console-xen-proto"
-  - OCAML_VERSION=4.07 PACKAGE="mirage-console-xen-backend"
-  - OCAML_VERSION=4.08 PACKAGE="mirage-console-xen"
-  - OCAML_VERSION=4.09 PACKAGE="mirage-console-unix"
+  - OCAML_VERSION=4.10 PACKAGE="mirage-console-unix"
+  - OCAML_VERSION=4.10 PACKAGE="mirage-console-xen"
+  - OCAML_VERSION=4.09 PACKAGE="mirage-console-xen-proto"
+  - OCAML_VERSION=4.09 PACKAGE="mirage-console-xen-backend"
+  - OCAML_VERSION=4.08 PACKAGE="mirage-console"

--- a/mirage-console-unix.opam
+++ b/mirage-console-unix.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/mirage-console"
 doc: "https://mirage.github.io/mirage-console/"
 bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.0"}
   "lwt" {>= "4.0.0"}
   "cstruct" {>= "4.0.0"}

--- a/mirage-console-xen-backend.opam
+++ b/mirage-console-xen-backend.opam
@@ -11,11 +11,10 @@ depends: [
   "dune" {>= "1.0"}
   "mirage-console" {=version}
   "mirage-console-xen-proto" {=version}
-  "mirage-xen" {>= "5.0.0"}
+  "mirage-xen" {>= "6.0.0"}
+  "io-page" {>= "2.0.0"}
   "lwt" {>= "4.0.0"}
-  "io-page-xen" {>= "2.0.0"}
   "xenstore"
-  "xen-evtchn"
   "shared-memory-ring-lwt"
 ]
 build: [

--- a/mirage-console-xen-backend.opam
+++ b/mirage-console-xen-backend.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/mirage-console"
 doc: "https://mirage.github.io/mirage-console/"
 bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.0"}
   "mirage-console" {=version}
   "mirage-console-xen-proto" {=version}

--- a/mirage-console-xen-proto.opam
+++ b/mirage-console-xen-proto.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/mirage-console"
 doc: "https://mirage.github.io/mirage-console/"
 bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.0"}
   "mirage-console" {= version}
   "rresult"

--- a/mirage-console-xen.opam
+++ b/mirage-console-xen.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/mirage-console"
 doc: "https://mirage.github.io/mirage-console/"
 bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.0"}
   "io-page" {>= "2.0.0"}
   "mirage-console" {=version}

--- a/mirage-console-xen.opam
+++ b/mirage-console-xen.opam
@@ -9,11 +9,10 @@ bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
+  "io-page" {>= "2.0.0"}
   "mirage-console" {=version}
   "mirage-console-xen-proto" {=version}
-  "xen-evtchn"
-  "io-page-xen"
-  "mirage-xen" {>= "5.0.0"}
+  "mirage-xen" {>= "6.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/mirage-console.opam
+++ b/mirage-console.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/mirage-console"
 doc: "https://mirage.github.io/mirage-console/"
 bug-reports: "https://github.com/mirage/mirage-console/issues"
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.0"}
   "mirage-device" {>= "2.0.0"}
   "mirage-flow" {>= "2.0.0"}

--- a/xen/backend/conback.mli
+++ b/xen/backend/conback.mli
@@ -25,7 +25,7 @@ module type ACTIVATIONS = sig
   val program_start: event
   (** represents an event which 'fired' when the program started *)
 
-  val after: Eventchn.t -> event -> event Lwt.t
+  val after: OS.Eventchn.t -> event -> event Lwt.t
   (** [next channel event] blocks until the system receives an event
       newer than [event] on channel [channel]. If an event is received
       while we aren't looking then this will be remembered and the

--- a/xen/backend/dune
+++ b/xen/backend/dune
@@ -2,5 +2,4 @@
  (name mirage_console_xen_backend)
  (public_name mirage-console-xen-backend)
  (libraries lwt mirage-xen xenstore xenstore.client io-page
-   shared-memory-ring mirage-console mirage-console-xen-proto)
- (flags :standard -safe-string))
+   shared-memory-ring mirage-console mirage-console-xen-proto))

--- a/xen/backend/dune
+++ b/xen/backend/dune
@@ -1,6 +1,6 @@
 (library
  (name mirage_console_xen_backend)
  (public_name mirage-console-xen-backend)
- (libraries lwt mirage-xen xenstore xenstore.client xen-evtchn
-   shared-memory-ring mirage-console mirage-console-xen-proto io-page-xen)
+ (libraries lwt mirage-xen xenstore xenstore.client io-page
+   shared-memory-ring mirage-console mirage-console-xen-proto)
  (flags :standard -safe-string))

--- a/xen/dune
+++ b/xen/dune
@@ -3,5 +3,4 @@
  (public_name mirage-console-xen)
  (libraries lwt xenstore shared-memory-ring io-page
    mirage-console-xen-proto mirage-console mirage-flow mirage-xen)
- (wrapped false)
- (flags :standard -safe-string))
+ (wrapped false))

--- a/xen/dune
+++ b/xen/dune
@@ -1,8 +1,7 @@
 (library
  (name mirage_console_xen)
  (public_name mirage-console-xen)
- (libraries lwt xenstore xen-evtchn shared-memory-ring
-   mirage-console-xen-proto mirage-console mirage-flow mirage-xen
-   io-page-xen)
+ (libraries lwt xenstore shared-memory-ring io-page
+   mirage-console-xen-proto mirage-console mirage-flow mirage-xen)
  (wrapped false)
  (flags :standard -safe-string))

--- a/xen/proto/dune
+++ b/xen/proto/dune
@@ -2,5 +2,4 @@
  (name mirage_console_xen_proto)
  (public_name mirage-console-xen-proto)
  (libraries xenstore rresult)
- (wrapped false)
- (flags :standard -safe-string))
+ (wrapped false))


### PR DESCRIPTION
Update mirage-console-xen to the interface changes in the new Xen core
platform stack.

Part of mirage/mirage#1159, depends on mirage/mirage-xen#23.